### PR TITLE
Raise error when strong_resource is not defined for a controller

### DIFF
--- a/lib/strong_resources/controller/mixin.rb
+++ b/lib/strong_resources/controller/mixin.rb
@@ -53,7 +53,10 @@ module StrongResources
       end
 
       def strong_resource
-        resource = self.class._strong_resources[action_name.to_sym]
+        resources = self.class._strong_resources
+        raise RuntimeError, "You need to define the `strong_resource` for #{class.name}" if resources.nil?
+        resource = resources[action_name.to_sym]
+        raise RuntimeError, "Missing `strong_resource` parameters for #{class.name}##{action_name}" if resource.nil?
         _params = params
         resource.permits(self)
       end

--- a/lib/strong_resources/controller/mixin.rb
+++ b/lib/strong_resources/controller/mixin.rb
@@ -54,9 +54,9 @@ module StrongResources
 
       def strong_resource
         resources = self.class._strong_resources
-        raise RuntimeError, "You need to define the `strong_resource` for #{class.name}" if resources.nil?
+        raise RuntimeError, "You need to define the `strong_resource` for #{self.class.name}" if resources.nil?
         resource = resources[action_name.to_sym]
-        raise RuntimeError, "Missing `strong_resource` parameters for #{class.name}##{action_name}" if resource.nil?
+        raise RuntimeError, "Missing `strong_resource` parameters for #{self.class.name}##{action_name}" if resource.nil?
         _params = params
         resource.permits(self)
       end


### PR DESCRIPTION
I ran into weird errors where the strong_resource was not defined in a controller that inherited a controller where the strong_resource was defined.

I am not sure `strong_resource` not propagating to inherited class is a bug (it's probably a good idea to always need to specify strong params/resource explicitely for each controller), so I'm just submitting a PR to make the bug more traceable. Since the `strong_resource` method involves callbacks it is completely invisible in the trace when it crashes (only framework trace, no app trace).

The resuting stack was hard to debug, so I thought adding meaningful exceptions would be better.

```
class BaseController
  strong_resource :user # Will not propagate
end

class RefinedController < BaseController
  # Need to redefine strong_resource !
  strong_resource :user
end
```