### PR TITLE
Fail-fast from config errors to avoid obscure error messages

### DIFF
--- a/lib/strong_resources/strong_resource.rb
+++ b/lib/strong_resources/strong_resource.rb
@@ -10,7 +10,7 @@ module StrongResources
     attr_reader :name, :customized_actions, :jsonapi_type
 
     def self.from(name, opts = {}, &blk)
-      config   = StrongResources.config.strong_resources[name]
+      config   = StrongResources.find(name)
       resource = new(name)
       resource.instance_eval(&config[:base])
       resource.instance_eval(&blk) if blk


### PR DESCRIPTION
This is just using the existing `#find` which already raises a helpful error message in the case of an unregistered resource.

Tested with appraisal rspec and found no errors.