### PR TITLE
Add number support

### DIFF
--- a/lib/strong_resources/configuration.rb
+++ b/lib/strong_resources/configuration.rb
@@ -24,6 +24,7 @@ module StrongResources
       strong_param :string, swagger: :string, type: ActionController::Parameters.string
       strong_param :integer, swagger: :integer, type: ActionController::Parameters.integer
       strong_param :boolean, swagger: :boolean, type: ActionController::Parameters.boolean
+      strong_param :number, swagger: :number, type: ActionController::Parameters.decimal
     end
   end
 end


### PR DESCRIPTION
This PR allows a number type to be used in `strong_resource`:

Example:
```
  strong_resource :requirement do
    attribute :weight, :number
  end
```

```
{
  "data": {
    "type": "requirements",
    "attributes": {
      "weight": 0.3
    }
  }
}
```