### PR TITLE
Fix nil has no keys bug

### DIFF
--- a/lib/strong_resources/strong_resource.rb
+++ b/lib/strong_resources/strong_resource.rb
@@ -93,11 +93,11 @@ module StrongResources
 
     def permits(controller)
       base_permits(self, controller).tap do |permits|
+        permits[:relationships] ||= {}
         self.relations.each_pair do |relation_name, opts|
           related_resource = opts[:resource]
           related = related_permits(related_resource, controller)
-
-          permits[:relationships] ||= {}
+          
           permits[:relationships][relation_name] = related
           permits
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,10 @@ StrongResources.configure do
   strong_resource :state do
     attribute :acronym, :string
   end
+
+  strong_resource :color do
+    attribute :name, :string
+  end
 end
 
 class PeopleController < ActionController::Base
@@ -62,6 +66,17 @@ class PeopleController < ActionController::Base
       remove_relationship :company
     end
   end
+
+  def create
+    render json: strong_resource
+  end
+end
+
+class ColorsController < ActionController::Base
+  include StrongResources::Controller::Mixin
+  include JsonapiCompliable::Base
+
+  strong_resource :color
 
   def create
     render json: strong_resource


### PR DESCRIPTION
There is a dastardly little bug where if you do not define any kind of relationships on your resource, but then try and pass some in, you will get the following error:

```
undefined method `has_key?' for nil:NilClass
```

This is in contrast to the regular behavior with relationships, where it allows whitelisted relationships in, and silently drops the remaining ones.

The two commits identify the error with a test, then fix it.