### PR TITLE
Show jsonapi-compliant errors on invalid param

### DIFF
--- a/lib/strong_resources.rb
+++ b/lib/strong_resources.rb
@@ -6,6 +6,10 @@ require "strong_resources/configuration"
 require "strong_resources/strong_resource"
 require "strong_resources/controller/mixin"
 
+if defined?(JsonapiErrorable)
+  require "strong_resources/exception_handler"
+end
+
 module StrongResources
   class UnregisteredResource < StandardError
     def initialize(name)

--- a/lib/strong_resources/controller/mixin.rb
+++ b/lib/strong_resources/controller/mixin.rb
@@ -8,6 +8,16 @@ module StrongResources
             attr_accessor :_strong_resources
           end
         end
+
+        # In cases when the full jsonapi suite is being used, we
+        # can provide much better error feedback when parameters are
+        # incorrect.  Without this handler, errors would be generic
+        # 500's with unhelpful statuses, but this will give API consumers
+        # better feedback about formatting errors with a 400 response.
+        if respond_to?(:register_exception)
+          register_exception StrongerParameters::InvalidParameter,
+            handler: StrongResources::ExceptionHandler
+        end
       end
 
       # TODO: refactor

--- a/lib/strong_resources/exception_handler.rb
+++ b/lib/strong_resources/exception_handler.rb
@@ -1,0 +1,35 @@
+module StrongResources
+  class ExceptionHandler < JsonapiErrorable::ExceptionHandler
+    SPLIT_REGEX = /^Invalid parameter: ([\w]+)\W(.*)/
+
+    def error_payload(error)
+      message_parse = error.message.match(SPLIT_REGEX)
+
+      attribute = message_parse[1]
+      message = message_parse[2]
+      error = {
+        code:   'unprocessable_entity',
+        status: '400',
+        title: 'Malformed Attribute',
+        detail: error.message,
+        source: { pointer: "/data/attributes/#{attribute}" },
+        meta:   {
+          attribute: attribute,
+          message: message
+        }
+      }
+
+      {
+        "errors" => [error]
+      }
+    end
+
+    def status_code(_)
+      400
+    end
+
+    def log?
+      false
+    end
+  end
+end

--- a/strong_resources.gemspec
+++ b/strong_resources.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "actionpack", [">= 4.1", "< 6.0"]
   spec.add_dependency "activesupport", [">= 4.1", "< 6.0"]
 
+  spec.add_development_dependency "jsonapi_errorable", "~> 0.9.0"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Previously, when requests were made that violated the formats being
checked by strong_resources, there was an error thrown which resulted
in a generic 500 error being sent back to the user, which wasn't
particularly helpful.  Those errors are now caught, parsed, and returned
as a jsonapi-compliant error object with a 400 (bad request) status.