### PR TITLE
Add helpful error message when type not found

### DIFF
--- a/lib/strong_resources.rb
+++ b/lib/strong_resources.rb
@@ -21,13 +21,20 @@ module StrongResources
     end
   end
 
-  class UnregisteredParam < StandardError
-    def initialize(name)
-      @name = name
+  class UnregisteredType < StandardError
+    def initialize(type)
+      @type = type
     end
 
     def message
-      "Parameter with name #{@name} not registered"
+      <<-MSG
+Type "#{@type}" was not found!
+
+This is the right-hand side of your strong_resource attributes.
+
+See the list of default types, and directions on how to register custom
+types, here: https://jsonapi-suite.github.io/strong_resources/#default-types
+      MSG
     end
   end
 
@@ -46,8 +53,8 @@ module StrongResources
   end
 
   def self.type_for_param(name)
-    found = config.strong_params[name][:type]
-    raise UnregisteredParam.new(name) unless found
-    found
+    found = config.strong_params[name]
+    raise UnregisteredType.new(name) unless found
+    found[:type]
   end
 end

--- a/spec/integration/strong_resource_spec.rb
+++ b/spec/integration/strong_resource_spec.rb
@@ -35,6 +35,28 @@ describe 'strong_resources' do
         .to be(true)
     end
 
+    context 'when unknown type is referenced' do
+      def with_type(val)
+        begin
+          action = controller.class._strong_resources[:create]
+          name = action.attributes[:name]
+          original = name[:type]
+          name[:type] = val
+          yield
+        ensure
+          name[:type] = original
+        end
+      end
+
+      it 'raises helpful error' do
+        with_type(:foo) do
+          expect {
+            controller.apply_strong_params
+          }.to raise_error(StrongResources::UnregisteredType)
+        end
+      end
+    end
+
     context 'when attribute is removed for the given action' do
       before do
         allow(controller).to receive(:action_name) { :update }


### PR DESCRIPTION
It sometimes happens, particularly with the generator, that sometimes we
encounter unknown types:

```ruby
StrongResources.configure do
  strong_resource :person do
    attribute :metadata, :jsonb
  end
end
```

`jsonb` here will be an unregistered type. Let's raise a helpful error
to cut down on debug time.